### PR TITLE
Support for DIYables 3.5 TFT LCD Color Touch Screen Shield

### DIFF
--- a/Drivers/io_gpio/lcdts_io_gpio8_hal.h
+++ b/Drivers/io_gpio/lcdts_io_gpio8_hal.h
@@ -80,12 +80,15 @@
 
 #define TS_AD_DELAY           5000
 
+/* Touchscreen reports pressure of touch. */
+#define TS_PRESSURE       1
+
 /* Select the AD channels (check in the cube which AD channel is connected to the RS and WR pins */
-#define TS_RS_ADCCH           ADC_CHANNEL_13
-#define TS_WR_ADCCH           ADC_CHANNEL_10
+#define TS_RS_ADCCH           ADC_CHANNEL_4
+#define TS_WR_ADCCH           ADC_CHANNEL_1
 
 /* these constants can be defined with the application appTouchCalib.c */
-#define  TS_CINDEX            {-1409179, -21, -107208, 42542238, 136441, -1509, -512509626}
+#define  TS_CINDEX            {-266, 82209, -10704, -210366973, 231263, -29964, -591817031}
 
 /* The touch value that it still accepts as the same value */
 #define TOUCH_FILTER          32

--- a/Drivers/lcd/ili9488.c
+++ b/Drivers/lcd/ili9488.c
@@ -171,6 +171,10 @@ static  uint16_t  yStart, yEnd;
 #define SETCURSOR(x, y)                    ILI9488_SETCURSOR(x, y)
 
 #elif ILI9488_INTERFACE == 2
+#if DIYABLES_QUIRK == 1
+#define SETWINDOW(x1, x2, y1, y2)          ILI9488_SETWINDOW(x1, x2, y1, y2)
+#define SETCURSOR(x, y)                    ILI9488_SETCURSOR(x, y)
+#else
 #if ILI9488_ORIENTATION == 0
 #define SETWINDOW(x1, x2, y1, y2)          ILI9488_SETWINDOW(ILI9488_MAX_X - (x2), ILI9488_MAX_X - (x1), y1, y2)
 #define SETCURSOR(x, y)                    ILI9488_SETCURSOR(ILI9488_MAX_X - (x), y)
@@ -183,6 +187,7 @@ static  uint16_t  yStart, yEnd;
 #elif ILI9488_ORIENTATION == 3
 #define SETWINDOW(x1, x2, y1, y2)          ILI9488_SETWINDOW(ILI9488_MAX_X - (x2), ILI9488_MAX_X - (x1), ILI9488_MAX_Y - (y2), ILI9488_MAX_Y - (y1))
 #define SETCURSOR(x, y)                    ILI9488_SETCURSOR(ILI9488_MAX_X - (x), ILI9488_MAX_Y - (y))
+#endif
 #endif
 #endif
 
@@ -323,6 +328,9 @@ void ili9488_Init(void)
   LCD_IO_WriteCmd8MultipleData8(ILI9488_DFUNCTR, (uint8_t *)"\x02\x02", 2); // Display Function Control RGB/MCU Interface Control
   LCD_IO_WriteCmd8MultipleData8(ILI9488_IMGFUNCT, (uint8_t *)"\x01", 1); // Set Image Functio (Disable 24 bit data)
   LCD_IO_WriteCmd8MultipleData8(ILI9488_ADJCTR3, (uint8_t *)"\xA9\x51\x2C\x82", 4); // Adjust Control (D7 stream, loose)
+#if DIYABLES_QUIRK == 1
+  LCD_IO_WriteCmd8MultipleData8(ILI9488_INVON, NULL, 0);
+#endif
   LCD_Delay(5);
   LCD_IO_WriteCmd8MultipleData8(ILI9488_SLPOUT, NULL, 0); // Exit Sleep
   LCD_Delay(120);

--- a/Drivers/lcd/ili9488.h
+++ b/Drivers/lcd/ili9488.h
@@ -2,7 +2,7 @@
    - 0: SPI half duplex (the mosi pin is bidirectional mode)
    - 1: SPI full duplex (write = mosi pin, read = miso pin)
    - 2: paralell 8 bit interface */
-#define ILI9488_INTERFACE     1
+#define ILI9488_INTERFACE     2
 
 /* Orientation:
    - 0: 320x480 micro-sd in the top (portrait)
@@ -30,3 +30,5 @@
 /* ILI9488 Size (physical resolution in default orientation) */
 #define  ILI9488_LCD_PIXEL_WIDTH   320
 #define  ILI9488_LCD_PIXEL_HEIGHT  480
+
+#define DIYABLES_QUIRK 1


### PR DESCRIPTION
Changes necessary to make the DIYables 3.5 TFT LCD Color Touch Screen Shield work when connected to a NUCLEO-F103RB system.  It has an 8-bit parallel interface using the GPIO driver.  With these changes it appears to pass all tests quite well, and has a responsive touch interface that reports pressure.  Several items are configuration items that likely shouldn't be committed to the master repo, but I wanted to first provide everything to make it work in case others want to reproduce and test.

The vendor's page: https://diyables.io/products/3.5-tft-lcd-color-touch-screen-shield-for-arduino-uno-mega-320x480-resolution-ili9488-driver-parallel-8-bit-interface-28pin-module-with-touch

Drivers/io_gpio/lcdts_io_gpio8_hal.c:

- ADC_SAMPLETIME_15CYCLES is not present in my generated files. Use ADC_SAMPLETIME_1CYCLE_5 which seems to work, there are other choices that might be better.  I believe this is due to my particular model of NUCLEO board or perhaps version of the STM32IDE, and not anything to do with the shield.

- TS_IO_DetectToch() (intentional mispelling to match existing) would not detect touches.  Referenced the DIYAbles code at https://github.com/DIYables/DIYables_TFT_Shield/blob/main/src/DIYables_TFT_Shield.cpp and rewrote the function.  This screen detects the touch pressure, so instead of the function simply returning true (1) or false (0) it now returns the pressure.  Values under 10 are returned as 0 to prevent spurious readings, although my unit pretty reliably returns 0 when there is no press.

  Wrap the new and old function in the TS_PRESSURE flag.

Drivers/io_gpio/lcdts_io_gpio8_hal.h:

- Set TS_RS_ADCCH and TS_WR_ADCCH to match the NUCLEO-F103RB ADC channels.

- Ran the App/TouchCalib and generated a new TS_CINDEX value to match my device.

- Add a new TS_PRESSURE flag.

Drivers/lcd/ili9488.c:

- The SETWINDOW and SETCURSOR functions do not need to be changed based on the ILI9488_ORIENTATION parameter with this board.  Add a new #if DIYABLES_QUIRK == 1 section that always uses the standard functions.

  Proper operation with all 4 values of ILI9488_ORIENTATION was confirmed after this change.

- In ili9488_Init() this board needs to have "ILI9488_INVON" set to get the proper colors.  That's right, INVON = not inverted while INVOFF = inverted.  Also wrap this in a #if DIYABLES_QUIRK == 1.

Drivers/lcd/ili9488.h:

- This board has a parallel interface, so set ILI9488_INTERFACE 2.

- Set the new variable DIYABLES_QUIRK to 1 to trigger the quirk handling above.